### PR TITLE
update 1.26.25.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ about:
   doc_url: https://github.com/python/typeshed/blob/main/README.md
   # License need to be packaged from upstream
   license_file: LICENSE
+  license_family: Apache-2.0
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -35,6 +37,8 @@ about:
     by people external to those projects.
   summary: Typing stubs for urllib3
   license: Apache-2.0
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://github.com/python/typeshed/blob/main/README.md
   # License need to be packaged from upstream
   license_file: LICENSE
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
   doc_url: https://github.com/python/typeshed/blob/main/README.md
   # License need to be packaged from upstream
   license_file: LICENSE
-  license_family: Apache-2.0
+  license_family: APACHE
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "types-urllib3" %}
-{% set version = "1.26.25.5" %}
+{% set version = "1.26.25.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,19 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-urllib3-{{ version }}.tar.gz
-  sha256: 5630e578246d170d91ebe3901788cd28d53c4e044dc2e2488e3b0d55fb6895d8
+  sha256: 3300538c9dc11dad32eae4827ac313f5d986b8b21494801f1bf97a1ac6c03ae5
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
+  skip: True  # [ py<38]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
+    - python
 
 test:
   commands:
@@ -29,6 +29,10 @@ test:
 
 about:
   home: https://github.com/python/typeshed
+  description: |
+    Typeshed contains external type annotations for the Python standard
+    library and Python builtins, as well as third party packages as contributed
+    by people external to those projects.
   summary: Typing stubs for urllib3
   license: Apache-2.0
   # License need to be packaged from upstream

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
-  skip: True  # [ py<38]
+  skip: True  # [py<38]
 
 requirements:
   host:
@@ -24,6 +24,8 @@ requirements:
     - python
 
 test:
+  imports:
+    - types
   commands:
     - pip check
   requires:


### PR DESCRIPTION
## `Types-Urllib3 1.26.25.13` Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1826)
[Upstream](https://github.com/python/typeshed)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added `wheel`, `setuptools` to `host` section
- Added `description`, `dev_url`,  to `about` section
- Added imported tests